### PR TITLE
admin=admin instead of id==6

### DIFF
--- a/Pages/delete_post.php
+++ b/Pages/delete_post.php
@@ -7,11 +7,11 @@ requireLogin();
 header('Content-Type: application/json');
 
 // Check if the user is admin
-$stmt = $pdo->prepare("SELECT user_id FROM users WHERE user_id = ?");
+$stmt = $pdo->prepare("SELECT username FROM users WHERE user_id = ?");
 $stmt->execute([$_SESSION['user_id']]);
 $user = $stmt->fetch();
 
-if ($user['user_id'] != 6) {
+if ($user['username'] !== 'Admin') {
     echo json_encode([
         'success' => false,
         'message' => 'Unauthorized access'

--- a/Pages/delete_user.php
+++ b/Pages/delete_user.php
@@ -7,11 +7,11 @@ requireLogin();
 header('Content-Type: application/json');
 
 // Check if the user is admin
-$stmt = $pdo->prepare("SELECT user_id FROM users WHERE user_id = ?");
+$stmt = $pdo->prepare("SELECT username FROM users WHERE user_id = ?");
 $stmt->execute([$_SESSION['user_id']]);
 $user = $stmt->fetch();
 
-if ($user['user_id'] != 6) {
+if ($user['username'] !== 'Admin') {
     echo json_encode([
         'success' => false,
         'message' => 'Unauthorized access'
@@ -32,7 +32,11 @@ if (!$userId) {
 }
 
 // Prevent deleting admin account
-if ($userId == 6) {
+$stmt = $pdo->prepare("SELECT username FROM users WHERE user_id = ?");
+$stmt->execute([$userId]);
+$targetUser = $stmt->fetch();
+
+if ($targetUser && $targetUser['username'] === 'Admin') {
     echo json_encode([
         'success' => false,
         'message' => 'Cannot delete admin account'

--- a/Pages/get_post.php
+++ b/Pages/get_post.php
@@ -12,11 +12,11 @@ ini_set('display_errors', 1);
 
 try {
     // Check if the user is admin
-    $stmt = $pdo->prepare("SELECT user_id FROM users WHERE user_id = ?");
+    $stmt = $pdo->prepare("SELECT username FROM users WHERE user_id = ?");
     $stmt->execute([$_SESSION['user_id']]);
     $user = $stmt->fetch();
 
-    if ($user['user_id'] != 6) {
+    if ($user['username'] !== 'Admin') {
         echo json_encode([
             'success' => false,
             'message' => 'Unauthorized access'

--- a/Pages/profile.php
+++ b/Pages/profile.php
@@ -9,7 +9,7 @@ $stmt->execute([$_SESSION['user_id']]);
 $user = $stmt->fetch();
 
 // Check if the logged-in user is admin
-$isAdmin = ($user['user_id'] == 6);
+$isAdmin = ($user['username'] === 'Admin');
 
 // If admin, get all users
 $allUsers = [];

--- a/Pages/update_post.php
+++ b/Pages/update_post.php
@@ -7,11 +7,11 @@ requireLogin();
 header('Content-Type: application/json');
 
 // Check if the user is admin
-$stmt = $pdo->prepare("SELECT user_id FROM users WHERE user_id = ?");
+$stmt = $pdo->prepare("SELECT username FROM users WHERE user_id = ?");
 $stmt->execute([$_SESSION['user_id']]);
 $user = $stmt->fetch();
 
-if ($user['user_id'] != 6) {
+if ($user['username'] !== 'Admin') {
     echo json_encode([
         'success' => false,
         'message' => 'Unauthorized access'

--- a/config/admin_functions.php
+++ b/config/admin_functions.php
@@ -3,7 +3,7 @@ require_once 'database.php';
 require_once 'session.php';
 
 function isAdmin() {
-    return isset($_SESSION['user_id']) && $_SESSION['user_id'] == 6;
+    return isset($_SESSION['username']) && $_SESSION['username'] === 'Admin';
 }
 
 function deleteUser($userId) {

--- a/config/database.php
+++ b/config/database.php
@@ -3,7 +3,8 @@ $host = 'localhost';
 $dbname = 'kmercha1';
 $username = 'kmercha1';
 $password = 'kmercha1';
-try {
+
+
     $pdo = new PDO("mysql:host=$host;dbname=$dbname", $username, $password);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch(PDOException $e) {


### PR DESCRIPTION
 Switch Admin Authorization from User ID to Username

 Description
This PR changes the admin authorization mechanism from checking `user_id == 6` to checking `username === 'Admin'`. This makes the admin privileges more explicit and easier to maintain by tying them to a specific username rather than a database ID.

 Changes Made
1. Updated `config/admin_functions.php`:
   - Modified `isAdmin()` function to check for username 'Admin' instead of user_id 6

2. Updated admin checks in multiple files:
   - `Pages/profile.php`
   - `Pages/delete_user.php`
   - `Pages/delete_post.php`
   - `Pages/update_post.php`
   - `Pages/get_post.php`

3. Updated admin account deletion prevention:
   - Now checks for username 'Admin' instead of user_id 6
   - Prevents deletion of the admin account based on username

Testing
Please test the following scenarios:
1. Login as Admin user - should have full admin privileges
2. Login as non-Admin user - should not have access to admin features
3. Try to delete Admin user - should be prevented
4. Admin features (user/post management) - should work as before

Security Considerations
- The change makes admin privileges more explicit and easier to audit
- Username comparison is case-sensitive for security
- All admin checks are server-side validated

Migration Notes
If you're upgrading an existing installation:
1. Ensure your admin user's username is set to "Admin"
2. If migrating from the user_id system, update the existing admin account's username
3. No database schema changes are required

Backwards Compatibility
This is a breaking change for systems that rely on user_id 6 for admin checks. All instances need to be updated to use the new username-based check.